### PR TITLE
BUG: fix duplicated entries for logged in user

### DIFF
--- a/library/plugins/models.py
+++ b/library/plugins/models.py
@@ -22,7 +22,7 @@ class GWARManager(models.Manager):
             return qs.filter(published=True)
         # Finally, for a regular, logged in user, only show them `published`
         # plugins, unless they are an author on an unpublished plugin.
-        return qs.filter(models.Q(authors=user) | models.Q(published=True))
+        return qs.filter(models.Q(authors=user) | models.Q(published=True)).distinct()
 
     def all(self, user):
         return self.get_queryset(user)


### PR DESCRIPTION
Fixes duplicate objects being returned when a user is an author, there are multiple authors, and the plugin is published.

I don't really understand why the ORM produced duplicates, I thought just setting `Q(authors=user, published=False)` would work, but the bridge table seems to be important to this somehow.