### PR TITLE
Update for flake8 v3.6

### DIFF
--- a/library/plugins/tests/test_views.py
+++ b/library/plugins/tests/test_views.py
@@ -1,5 +1,3 @@
-import unittest
-
 from django import test
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group

--- a/library/plugins/tests/test_views.py
+++ b/library/plugins/tests/test_views.py
@@ -63,7 +63,7 @@ class AnonymousUserAuthorizationTests(test.TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_plugin_detail_published(self):
-        plugin = Plugin.unsafe.create( **{**_BASE_PLUGIN, 'title': 'published_plugin'})
+        plugin = Plugin.unsafe.create(**{**_BASE_PLUGIN, 'title': 'published_plugin'})
 
         response = self.client.get('/plugins/%s/%d/' % (plugin.slug, plugin.id))
 
@@ -96,7 +96,8 @@ class AnonymousUserAuthorizationTests(test.TestCase):
 class LoggedInUserAuthorizationTests(test.TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.user = User.objects.create_user('user',
+        cls.user = User.objects.create_user(
+            'user',
             **{**_BASE_USER, 'forum_external_id': '1', 'password': 'peanut'})
 
     def setUp(self):
@@ -132,7 +133,7 @@ class LoggedInUserAuthorizationTests(test.TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_plugin_detail_published(self):
-        plugin = Plugin.unsafe.create( **{**_BASE_PLUGIN, 'title': 'published_plugin'})
+        plugin = Plugin.unsafe.create(**{**_BASE_PLUGIN, 'title': 'published_plugin'})
 
         response = self.client.get('/plugins/%s/%d/' % (plugin.slug, plugin.id))
 
@@ -160,10 +161,12 @@ class LoggedInUserAuthorizationTests(test.TestCase):
 
         self.assertEqual(response.status_code, 404)
 
+
 class AuthorAuthorizationTests(test.TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.user = User.objects.create_user('author',
+        cls.user = User.objects.create_user(
+            'author',
             **{**_BASE_USER, 'forum_external_id': '1', 'password': 'peanut'})
         cls.user.groups.add(Group.objects.get(name='forum_trust_level_1'))
 
@@ -280,7 +283,8 @@ class AuthorAuthorizationTests(test.TestCase):
 class AdminAuthorizationTests(test.TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.user = User.objects.create_user('admin',
+        cls.user = User.objects.create_user(
+            'admin',
             **{**_BASE_USER, 'forum_external_id': '1', 'password': 'peanut',
                'is_superuser': True, 'forum_is_admin': True})
 

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -1,0 +1,4 @@
+travis.txt:
+-r local.txt
+
+# NOTHING TO SEE HERE

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,17 @@
+dist: trusty
+sudo: false
+language: python
+python:
+  -3.6
+addons:
+  postgresql: '11.1'
+before_install:
+  - psql -c 'create database testdb;' -U postgres
+  - export DJANGO_SETTINGS_MODULE=config.settings.travis
+  - export DATABASE_URL=postgres://postgres@localhost/testdb
+install:
+  - pip install -r requirements/travis.txt
+  - pip install -q https://github.com/qiime2/q2lint/archive/master.zip
+script:
+  - python manage.py migrate
+  - make lint


### PR DESCRIPTION
minor changes for flake8 compliance

NOTE: Proceed with caution, unable to test successfully. 
Py.test crashes on a clean *master* branch as follows:

ERROR collecting library/plugins/tests/test_views.py
ImportError while importing test module '/home/chris/src/qiime2/library/library/plugins/tests/test_views.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
library/plugins/tests/test_views.py:3: in <module>   from django import test
E   ImportError: No module named 'django'