### PR TITLE
Initial commit for bug #19 fix.

### DIFF
--- a/library/plugins/forms.py
+++ b/library/plugins/forms.py
@@ -69,6 +69,23 @@ class PluginAuthorshipForm(forms.ModelForm):
         }
 
 
-PluginAuthorshipFormSet = forms.inlineformset_factory(
-        Plugin, PluginAuthorship, form=PluginAuthorshipForm, extra=1,
-        fk_name='plugin')
+class PluginAuthorshipFormSet(forms.inlineformset_factory(
+        Plugin, PluginAuthorship,
+        extra=1,
+        form=PluginAuthorshipForm,
+        fk_name='plugin')):
+
+    def __init__(self, *args, **kwargs):
+        self.user = kwargs.pop('user')
+        super().__init__(*args, **kwargs)
+
+    # Overriding the clean() to add our custom validation.
+    def clean(self):
+        user_not_in_author_list = True
+        for form in self.forms:
+            if self.user == form.cleaned_data.get('author'):
+                user_not_in_author_list = False
+        if user_not_in_author_list:
+            raise forms.ValidationError('You must enter yourself as an author. '
+                                        'Save the plugin to ad additional authors.', code='author_error1')
+        return

--- a/library/plugins/forms.py
+++ b/library/plugins/forms.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.forms import BaseInlineFormSet
 
 from .models import Plugin, PluginAuthorship
 

--- a/library/plugins/forms.py
+++ b/library/plugins/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.forms import BaseInlineFormSet
 
 from .models import Plugin, PluginAuthorship
 
@@ -87,5 +88,5 @@ class PluginAuthorshipFormSet(forms.inlineformset_factory(
                 user_not_in_author_list = False
         if user_not_in_author_list:
             raise forms.ValidationError('You must enter yourself as an author. '
-                                        'Save the plugin to ad additional authors.', code='author_error1')
+                                        'Save the plugin to add additional authors.', code='author_error1')
         return

--- a/library/plugins/views.py
+++ b/library/plugins/views.py
@@ -50,13 +50,14 @@ class PluginNew(LoginRequiredMixin, PermissionRequiredMixin, CreateView):
 
     def get(self, request, *args, **kwargs):
         self.object = None
-        ctx = self.get_context_data(form=self.get_form(), author_formset=PluginAuthorshipFormSet())
+        ctx = self.get_context_data(form=self.get_form(),
+                                    author_formset=PluginAuthorshipFormSet(user=self.request.user))
         return self.render_to_response(ctx)
 
     def post(self, request, *args, **kwargs):
         self.object = None
         form = self.get_form()
-        author_formset = PluginAuthorshipFormSet(self.request.POST)
+        author_formset = PluginAuthorshipFormSet(self.request.POST, user=self.request.user)
         form_is_valid = form.is_valid()
         author_formset_is_valid = author_formset.is_valid()
         if form_is_valid and author_formset_is_valid:
@@ -99,13 +100,13 @@ class PluginEdit(LoginRequiredMixin, RedirectSlugMixin, UpdateView):
         ctx = self.get_context_data(
             form=self.get_form(),
             author_formset=PluginAuthorshipFormSet(instance=self.object,
-                                                   queryset=qs))
+                                                   queryset=qs, user=self.request.user))
         return self.render_to_response(ctx)
 
     def post(self, request, *args, **kwargs):
         self.object = self.get_object()
         form = self.get_form()
-        author_formset = PluginAuthorshipFormSet(self.request.POST, instance=self.object)
+        author_formset = PluginAuthorshipFormSet(self.request.POST, instance=self.object, user=self.request.user)
         form_is_valid = form.is_valid()
         author_formset_is_valid = author_formset.is_valid()
         if form_is_valid and author_formset_is_valid:

--- a/library/templates/plugins/plugin_form.html
+++ b/library/templates/plugins/plugin_form.html
@@ -60,7 +60,7 @@
           </thead>
           <tbody>
           {% for author_form in author_formset %}
-            <tr class="has-text-danger"><td colspan="3">{{ author_form.non_field_errors }}</td></tr>
+            <tr class="has-text-danger"><td colspan="3">{{ author_form.non_field_errors }}{{ author_formset.non_form_errors }}</td></tr>
             <tr {% if author_form.errors %}class="has-background-danger"{% endif %}>
               <td>
                 {# Tuck these here for safe-keeping #}


### PR DESCRIPTION
### Brief summary:
We fixed the issue that prevented authors from editing their plugins by:

 + Creating a new field in the Plugin model, 'created_by'
    + This field would be automatically populated with the current user when they attempt to save a new instance of a plugin. This provides a fail safe to the original author in the event that they forget to add themselves as authors, and subsequently not having permission to edit.

NOTE: This fix only works from plugins that are created from **now on**, any previous plugins will need to be updated with correct authors.


**Co-authored-by:** 
- - Joseph Remy - [J1411](https://github.com/J1411)
- - Tanner Massahos - [tanman987](https://github.com/tanman987)
- - Julian Bell - [jbell-97](https://github.com/jbell-97)


---

Include any questions for reviewers, screenshots, sample outputs, etc.
