### PR TITLE
bug: fastcore API change

### DIFF
--- a/library/api/utils.py
+++ b/library/api/utils.py
@@ -21,7 +21,7 @@ import zipfile
 
 from django import conf
 from django.db import connection
-from fastcore.utils import HTTP404NotFoundError
+from fastcore.net import HTTP404NotFoundError
 from ghapi.all import GhApi
 import yaml
 


### PR DESCRIPTION
HTTP404NotFoundError moved from fastcore.utils to fastcore.net causing CI failures